### PR TITLE
feat!: migrate to askama 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "askama"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+checksum = "bb7125972258312e79827b60c9eb93938334100245081cf701a2dee981b17427"
 dependencies = [
- "askama_derive",
+ "askama_macros",
  "itoa",
  "percent-encoding",
  "serde",
@@ -17,7 +17,7 @@ dependencies = [
 
 [[package]]
 name = "askama-markdown-cmark"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "askama",
  "pulldown-cmark",
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+checksum = "8ba5e7259a1580c61571e3116ebaaa01e3c001b2132b17c4cc5c70780ca3e994"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -41,14 +41,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "askama_parser"
-version = "0.14.0"
+name = "askama_macros"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+checksum = "236ce20b77cb13506eaf5024899f4af6e12e8825f390bd943c4c37fd8f322e46"
 dependencies = [
- "memchr",
+ "askama_derive",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c63392767bb2df6aa65a6e1e3b80fd89bb7af6d58359b924c0695620f1512e"
+dependencies = [
+ "rustc-hash",
  "serde",
  "serde_derive",
+ "unicode-ident",
  "winnow",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askama-markdown-cmark"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["blakehawkins <blake.hawkins.11@gmail.com>"]
 edition = "2024"
 description = "Askama filter for markdown, using pulldown-cmark."
@@ -11,5 +11,5 @@ keywords = ["askama", "templating", "markdown", "md", "commonmark"]
 license = "Apache-2.0/MIT"
 
 [dependencies]
-askama = { version = "0.14", features = ["derive"] }
+askama = { version = "0.15", features = ["derive"] }
 pulldown-cmark = "0.13"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod filters {
     ///     Ok(())
     /// }
     /// ```
+    #[askama::filter_fn]
     pub fn markdown_cmark<T: fmt::Display>(
         s: T,
         _: &dyn askama::Values,


### PR DESCRIPTION
Resolves https://github.com/blakehawkins/askama-markdown-cmark/issues/1.

#### Test passes

```
❯ cargo test
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running unittests src/lib.rs (target/debug/deps/askama_markdown_cmark-49d0fc5c38629f2f)

running 1 test
test tests::markdown ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests askama_markdown_cmark

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

#### Example produces expected output

```
❯ cargo run --example example
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/examples/example`
<!doctype html>

<html>
    <head><title>test</title></head>

    <body>
        <p><strong>And I oop</strong></p>

    </body>
</html>
```

